### PR TITLE
remove GDAL from R-4.5.1-gfbf-2023a-bare-noSciPy.eb to stop crytograp…

### DIFF
--- a/easyconfigs/r/R-4.5.1-gfbf-2023a-bare-noSciPy.eb
+++ b/easyconfigs/r/R-4.5.1-gfbf-2023a-bare-noSciPy.eb
@@ -50,7 +50,7 @@ dependencies = [
     ('ImageMagick', '7.1.1-15', '', ('GCCcore', '12.3.0')),
     ('GLPK', '5.0', '', ('GCCcore', '12.3.0')),
     ('nodejs', '18.17.1', '', ('GCCcore', '12.3.0')),
-    ('GDAL', '3.7.1', '', ('foss', '2023a')),  # Note: check if needs versionsuffix
+#    ('GDAL', '3.7.1', '', ('foss', '2023a')),  # Note: check if needs versionsuffix - Dropping GDAL altogether for the moment
     ('MPFR', '4.2.0', '', ('GCCcore', '12.3.0')),
     ('libgit2', '1.7.1', '', ('GCCcore', '12.3.0')),
     ('OpenSSL', '1.1', '', SYSTEM),


### PR DESCRIPTION
remove GDAL from R-4.5.1-gfbf-2023a-bare-noSciPy.eb to stop crytography library being pulled in which in turn cause issues with Posit Workbench host